### PR TITLE
Minor refactoring/Added blips and peds

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,39 +19,53 @@ https://user-images.githubusercontent.com/91488137/198853647-500635d1-a7ff-442f-
 * Drag and drop `razed-mysterybox`
 * In your `server.cfg` add `ensure razed-mysterybox`
 * In `images` add the images to `qb-inventory/html/images`
+* In your `qb-core/shared/items.lua` add 
+```
+['lowmysterybox'] 			     = {['name'] = 'lowmysterybox', 				['label'] = 'Low Tier Mystery Box',     ['weight'] = 500, 		['type'] = 'item', 		['image'] = 'lowmysterybox.png', 		['unique'] = false,     ['useable'] = true, 	['shouldClose'] = true,	   ['combinable'] = nil,   ['description'] = 'It\' an alright mystery box which includes some random but useful items, perfect if you\'re broke.'},
+['premiummysterybox'] 			 = {['name'] = 'premiummysterybox', 			['label'] = 'Premium Box', 				['weight'] = 500, 		['type'] = 'item', 		['image'] = 'highmysterybox.png', 	    ['unique'] = false, 	['useable'] = true, 	['shouldClose'] = true,	   ['combinable'] = nil,   ['description'] = 'An amazing mystery box which includes some top-notch items, perfect for your \'RICH\' lifestyle.'},
+```
 
 
 # Config
 ```
 Config = {}
+local model = 'a_m_m_business_01'
 
 Config.Status = '^5Version 1.0'
-Config.TargetDistance = 5
+Config.TargetDistance = 1
 
-Config.Shop = {
-    'a_m_m_business_01'
-}
-
-Config.Location = {
-    x = 259.32,
-    y = -998.41,
-    z = 28.26,
-    h = 69.03
+Config.BlipLocation = {
+    vector3(195.66, -1009.5, 29.31),
 }
 
 --Blip
-Config.BlipName = "Mystery Boxes"
-Config.BlipColour = 1
-Config.BlipScale = 0.5
+Config.Blip = {
+blipName = "Mystery Boxes",
+blipType = 465,
+blipColor = 5,
+blipScale = 0.9,
+}
+
+Config.Location = {
+    [1] = {
+        coords = vector4(195.66, -1009.5, 29.31, 160.0),
+        model = model,
+    },
+
+    -- [2] = {
+    --     coords = vector4(x, y, z, w),
+    --     model = model,
+    -- },
+}
 
 --Low Tier Box
 Config.LowTierRewards = {
     items = {
     --  {'item_name', chance},
-        {'peanutmandms', 1}, 
+        {'snikkel_candy', 1}, 
         {'sandwich', math.random(1,6)},
-        {'hersheysbar', math.random(1,6)},
-        {'cocacola', math.random(1,6)},
+        {'twerks_candy', math.random(1,6)},
+        {'kurkakola', math.random(1,6)},
     }
 }
 Config.LowTierPrice = '500'
@@ -61,7 +75,7 @@ Config.LowTierPrice = '500'
 Config.PremiumTierRewards = {
     items = {
     --  {'item_name', chance},
-        {'peanutmandms', math.random(1,6)}, 
+        {'snikkel_candy', math.random(1,6)}, 
         {'phone', math.random(1,6)},
         {'laptop', math.random(1,6)},
         {'diamond_ring', math.random(1,50)},

--- a/client.lua
+++ b/client.lua
@@ -1,6 +1,42 @@
-local QBCore = exports['qb-core']:GetCoreObject()
- 
- exports['qb-target']:AddTargetModel(Config.Shop, {
+local blips = {} 
+
+local function createBlips()
+  for k, v in pairs(Config.BlipLocation) do
+      blips[k] = AddBlipForCoord(tonumber(v.x), tonumber(v.y), tonumber(v.z))
+      SetBlipSprite(blips[k], Config.Blip.blipType)
+      SetBlipDisplay(blips[k], 4)
+      SetBlipScale  (blips[k], Config.Blip.blipScale)
+      SetBlipColour (blips[k], Config.Blip.blipColor)
+      SetBlipAsShortRange(blips[k], true)
+      BeginTextCommandSetBlipName("STRING")
+      AddTextComponentString(tostring(Config.Blip.blipName))
+      EndTextCommandSetBlipName(blips[k])
+  end
+end
+
+local function removeBlips()
+  for k, _ in pairs(Config.BlipLocation) do
+      RemoveBlip(blips[k])
+  end
+  blips = {}
+end
+
+local function createSeller()
+  for i = 1, #Config.Location do
+      local current = Config.Location[i]
+      current.model = type(current.model) == 'string' and GetHashKey(current.model) or current.model
+      RequestModel(current.model)
+      while not HasModelLoaded(current.model) do
+          Wait(0)
+      end
+      local currentCoords = vector4(current.coords.x, current.coords.y, current.coords.z - 1, current.coords.w)
+      local ped = CreatePed(0, current.model, currentCoords, false, false)
+      FreezeEntityPosition(ped, true)
+      SetEntityInvincible(ped, true)
+      SetBlockingOfNonTemporaryEvents(ped, true)
+      
+  end
+  exports['qb-target']:AddTargetModel('a_m_m_business_01', {
     options = {
     {
       type = "client",
@@ -11,40 +47,58 @@ local QBCore = exports['qb-core']:GetCoreObject()
   },
   distance = Config.TargetDistance,
 })
+end
+
+RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+  createBlips()
+  createSeller()
+end)
+
+RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
+  removeBlips()
+end)
+
+AddEventHandler('onResourceStart', function(resource)
+    if GetCurrentResourceName() == resource then
+      Wait(100)
+      createBlips()
+      createSeller()
+    end
+end)
+
+----------------------------------------------------------------------------------------
 
 RegisterNetEvent('razed-mysterybox:openMenu', function()
   exports['qb-menu']:openMenu({
       {
-          header = "Mystery box Shop",
+          header = 'Mystery box Shop',
           isMenuHeader = true,
       },
       {
           id = 1,
-          header = "Low-Tier Mystery Box",
-          txt = "Price:" ..Config.LowTierPrice.. " - It's an alright mystery box which inclues some random but useful items, perfect is you're broke.",
+          header = 'Low-Tier Mystery Box',
+          txt = 'Price:' ..Config.LowTierPrice.. ' - It\'s an alright mystery box which inclues some random but useful items, perfect is you\'re broke.',
           params = {
-              event = "razed-mysterybox:GiveLowTierMysteryBox",
+              event = 'razed-mysterybox:GiveLowTierMysteryBox',
           }
       },
     {
       id = 2,
-      header = "Premium-Tier Mystery Box",
-      txt = "Price:"  ..Config.PremiumTierPrice..  " - An amazing mystery box which includes some top-notch items, perfect for your 'rich' lifestyle, if you can afford it.",
+      header = 'Premium-Tier Mystery Box',
+      txt = 'Price:'  ..Config.PremiumTierPrice..  ' - An amazing mystery box which includes some top-notch items, perfect for your \'rich\' lifestyle, if you can afford it.',
       params = {
-          event = "razed-mysterybox:GivePremiumTierMysteryBox",
+          event = 'razed-mysterybox:GivePremiumTierMysteryBox',
       }
   },  
 })
 end)
 
 --Low Tier
-RegisterNetEvent('razed-mysterybox:GiveLowTierMysteryBox')
-AddEventHandler('razed-mysterybox:GiveLowTierMysteryBox', function()
-  TriggerServerEvent('razed-mysterybox:GiveLowTierMysteryBox1', idk, idk, money)
+RegisterNetEvent('razed-mysterybox:GiveLowTierMysteryBox', function()
+  TriggerServerEvent('razed-mysterybox:GiveLowTierMysteryBox1')
 end)
 
 --Premium Tier
-RegisterNetEvent('razed-mysterybox:GivePremiumTierMysteryBox')
-AddEventHandler('razed-mysterybox:GivePremiumTierMysteryBox', function()
-  TriggerServerEvent('razed-mysterybox:GivePremiumTierMysteryBox1', idk, idk, money)
+RegisterNetEvent('razed-mysterybox:GivePremiumTierMysteryBox', function()
+  TriggerServerEvent('razed-mysterybox:GivePremiumTierMysteryBox1')
 end)

--- a/config.lua
+++ b/config.lua
@@ -1,21 +1,41 @@
 Config = {}
+local model = 'a_m_m_business_01'
 
 Config.Status = '^5Version 1.0'
-Config.TargetDistance = 5
+Config.TargetDistance = 1
 
-Config.Shop = {
-    'a_m_m_business_01'
+Config.BlipLocation = {
+    vector3(195.66, -1009.5, 29.31),
 }
 
+--Blip
+Config.Blip = {
+blipName = "Mystery Boxes",
+blipType = 465,
+blipColor = 5,
+blipScale = 0.9,
+}
+
+Config.Location = {
+    [1] = {
+        coords = vector4(195.66, -1009.5, 29.31, 160.0),
+        model = model,
+    },
+
+    -- [2] = {
+    --     coords = vector4(x, y, z, w),
+    --     model = model,
+    -- },
+}
 
 --Low Tier Box
 Config.LowTierRewards = {
     items = {
     --  {'item_name', chance},
-        {'peanutmandms', 1}, 
+        {'snikkel_candy', 1}, 
         {'sandwich', math.random(1,6)},
-        {'hersheysbar', math.random(1,6)},
-        {'cocacola', math.random(1,6)},
+        {'twerks_candy', math.random(1,6)},
+        {'kurkakola', math.random(1,6)},
     }
 }
 Config.LowTierPrice = '500'
@@ -25,7 +45,7 @@ Config.LowTierPrice = '500'
 Config.PremiumTierRewards = {
     items = {
     --  {'item_name', chance},
-        {'peanutmandms', math.random(1,6)}, 
+        {'snikkel_candy', math.random(1,6)}, 
         {'phone', math.random(1,6)},
         {'laptop', math.random(1,6)},
         {'diamond_ring', math.random(1,50)},

--- a/server.lua
+++ b/server.lua
@@ -16,27 +16,29 @@ RegisterNetEvent('razed-mysterybox:GiveLowTierMysteryBox1')
 RegisterNetEvent('razed-mysterybox:GiveLowTierMysteryBox1', function()
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    Player.Functions.AddItem("lowmysterybox")
-    Player.Functions.RemoveMoney("cash", Config.LowTierPrice)
+    Player.Functions.AddItem('lowmysterybox')
+    TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items['lowmysterybox'], 'add')
+    Player.Functions.RemoveMoney('cash', Config.LowTierPrice)
 end)
 
 QBCore.Functions.CreateUseableItem('lowmysterybox', function(source, item)
 	local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    local FoundItem = Config.LowTierRewards["items"][math.random(1, #Config.LowTierRewards["items"])]
+    local FoundItem = Config.LowTierRewards['items'][math.random(1, #Config.LowTierRewards['items'])]
 
-    TriggerClientEvent('QBCore:Notify', src, "Opening the box!", "success")
+    TriggerClientEvent('QBCore:Notify', src, 'Opening the box!', 'success')
 
      Wait(2000)
 
-     TriggerClientEvent('QBCore:Notify', src, "Lets see what you got!")
+     TriggerClientEvent('QBCore:Notify', src, 'Lets see what you got!')
 
      Wait(4000)
 
-
     if Player.Functions.RemoveItem(item.name, 1, item.slot) then
-    TriggerClientEvent('qb-inventory:client:ItemBox', source, QBCore.Shared.Items['lowmysterybox'], "remove")
-    TriggerClientEvent('QBCore:Notify', src, "You got a "..FoundItem[1].."!", "success")
+    TriggerClientEvent('qb-inventory:client:ItemBox', source, QBCore.Shared.Items['lowmysterybox'], 'remove')
+    TriggerClientEvent('QBCore:Notify', src, 'You got a '..FoundItem[1]..'!', 'success')
+    TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[FoundItem[1]], 'add')
+    TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[FoundItem[2]], 'add')
     Player.Functions.AddItem(FoundItem[1], FoundItem[2])
     end
 
@@ -47,27 +49,30 @@ RegisterNetEvent('razed-mysterybox:GivePremiumTierMysteryBox1')
 RegisterNetEvent('razed-mysterybox:GivePremiumTierMysteryBox1', function()
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    Player.Functions.AddItem("premiummysterybox")
-    Player.Functions.RemoveMoney("cash", Config.PremiumTierPrice)
+    Player.Functions.AddItem('premiummysterybox')
+    TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items['premiummysterybox'], 'add')
+    Player.Functions.RemoveMoney('cash', Config.PremiumTierPrice)
 end)
 
 QBCore.Functions.CreateUseableItem('premiummysterybox', function(source, item)
 	local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    local FoundItem = Config.PremiumTierRewards["items"][math.random(1, #Config.PremiumTierRewards["items"])]
+    local FoundItem = Config.PremiumTierRewards['items'][math.random(1, #Config.PremiumTierRewards['items'])]
 
-    TriggerClientEvent('QBCore:Notify', src, "Opening the box!", "success")
+    TriggerClientEvent('QBCore:Notify', src, 'Opening the box!', 'success')
 
      Wait(2000)
 
-     TriggerClientEvent('QBCore:Notify', src, "Lets see what you got!")
+     TriggerClientEvent('QBCore:Notify', src, 'Lets see what you got!')
 
      Wait(4000)
 
 
     if Player.Functions.RemoveItem(item.name, 1, item.slot) then
-    TriggerClientEvent('qb-inventory:client:ItemBox', source, QBCore.Shared.Items['premiummysterybox'], "remove")
-    TriggerClientEvent('QBCore:Notify', src, "You got a "..FoundItem[1].."!", "success")
+    TriggerClientEvent('qb-inventory:client:ItemBox', source, QBCore.Shared.Items['premiummysterybox'], 'remove')
+    TriggerClientEvent('QBCore:Notify', src, 'You got a '..FoundItem[1]..'!', 'success')
+    TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[FoundItem[1]], 'add')
+    TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[FoundItem[2]], 'add')
     Player.Functions.AddItem(FoundItem[1], FoundItem[2])
     end
 


### PR DESCRIPTION
### client.lua
- Added blips
- Added spawnable peds
- Able to restart script without having to logout

### server.lua
- You can now see what you have gotten from the mystery box
https://i.imgur.com/0mDiXdG.png

### config.lua
- Changed the distance for which the third eye can be toggled
- Added blip config
- Added Ped config
- Able to add multiple peds around the map if wanted

### README.md
- Some people wouldn't know how to install this since it didn't tell you to add the items to `qb-core/shared/items.lua` in which I have added
- Updated the config section of the readme

### Suggestions
- Figure out how to implement the progressbar function since you can just spam the hell out of the boxes. The progressbar can prevent spamming and be able to only open one box at a time
- Find a more optimal way to spawn peds/show blips. - i.e. Build the config to use blips and peds in one section instead of multiple sections.